### PR TITLE
Use patchelf 0.18.0 on linux aarch64-linux

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -268,7 +268,7 @@ pipeline {
                     }
                     environment {
                         TARGET = "${LINUX_ARM64_TARGET}"
-                        PATH = "$HOME/.cargo/bin:$PATH"
+                        PATH = "$HOME/.cargo/bin:$HOME/patchelf/bin:$PATH"
                         OPENSSL_STATIC = 1
                         OPENSSL_LIB_DIR = "/usr/lib/aarch64-linux-gnu"
                         OPENSSL_INCLUDE_DIR = "/usr/include/openssl"


### PR DESCRIPTION
When packaging glamorous toolkit for nixpkgs on aarch64, I encountered the same problem that was addressed in c8f1642: glamorous toolkit is using an older version of patchelf than the one in nixpkgs, which prevents nixpkgs from patching the binaries again.

I'm assuming that the same fix will work for aarch64, but let me know if that's wrong.